### PR TITLE
fix: fixed reindexing of unchanged files, now uses last_modified stamp

### DIFF
--- a/gptme_rag/indexing/indexer.py
+++ b/gptme_rag/indexing/indexer.py
@@ -92,6 +92,7 @@ class Indexer:
             self.persist_directory = Path(persist_directory).expanduser().resolve()
             self.persist_directory.mkdir(parents=True, exist_ok=True)
             logger.info(f"Using persist directory: {self.persist_directory}")
+
             settings.persist_directory = str(self.persist_directory)
             self.client = chromadb.PersistentClient(
                 path=str(self.persist_directory), settings=settings
@@ -516,6 +517,9 @@ class Indexer:
         """
         # Get all documents from collection
         results = self.collection.get()
+        logger.debug("ChromaDB returned %d documents", len(results["ids"]))
+        if results["ids"]:
+            logger.debug("First document metadata: %s", results["metadatas"][0])
 
         if not results["ids"]:
             return []
@@ -912,4 +916,8 @@ class Indexer:
         Returns:
             List of all documents in the index, including all chunks.
         """
-        return self.list_documents(group_by_source=False)
+        logger.debug("Getting all documents from index")
+        docs = self.list_documents(group_by_source=False)
+        for doc in docs:
+            logger.debug("Retrieved document with metadata: %s", doc.metadata)
+        return docs

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from pathlib import Path
+from datetime import datetime
 
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
@@ -321,7 +322,9 @@ class IndexEventHandler(FileSystemEventHandler):
 
         # Sort updates by modification time to get latest versions
         updates = sorted(
-            existing_updates, key=lambda p: p.stat().st_mtime, reverse=True
+            existing_updates,
+            key=lambda p: datetime.fromtimestamp(p.stat().st_mtime),
+            reverse=True,
         )
         logger.debug(f"Sorted updates: {[str(p) for p in updates]}")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix reindexing of unchanged files by using `last_modified` timestamp in `cli.py` and improve logging in `indexer.py` and `watcher.py`.
> 
>   - **Behavior**:
>     - Fix reindexing of unchanged files in `index()` in `cli.py` by using `last_modified` timestamp instead of `mtime`.
>     - Compare timestamps rounded to microseconds to determine file changes.
>   - **Logging**:
>     - Add debug logs in `list_documents()` and `get_all_documents()` in `indexer.py` to log document retrieval details.
>     - Add debug logs in `_process_updates()` in `watcher.py` to log sorted updates by modification time.
>   - **Misc**:
>     - Remove `mtime` metadata handling in `cli.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme-rag&utm_source=github&utm_medium=referral)<sup> for 50147e70bf82f1030a4520a860f7205de0c44027. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->