### PR TITLE
fix: fixed reindexing of unchanged files, now uses last_modified stamp

### DIFF
--- a/gptme_rag/indexing/indexer.py
+++ b/gptme_rag/indexing/indexer.py
@@ -92,6 +92,7 @@ class Indexer:
             self.persist_directory = Path(persist_directory).expanduser().resolve()
             self.persist_directory.mkdir(parents=True, exist_ok=True)
             logger.info(f"Using persist directory: {self.persist_directory}")
+
             settings.persist_directory = str(self.persist_directory)
             self.client = chromadb.PersistentClient(
                 path=str(self.persist_directory), settings=settings
@@ -516,6 +517,9 @@ class Indexer:
         """
         # Get all documents from collection
         results = self.collection.get()
+        logger.debug("ChromaDB returned %d documents", len(results["ids"]))
+        if results["ids"]:
+            logger.debug("First document metadata: %s", results["metadatas"][0])
 
         if not results["ids"]:
             return []
@@ -912,4 +916,8 @@ class Indexer:
         Returns:
             List of all documents in the index, including all chunks.
         """
-        return self.list_documents(group_by_source=False)
+        logger.debug("Getting all documents from index")
+        docs = self.list_documents(group_by_source=False)
+        for doc in docs:
+            logger.debug("Retrieved document with metadata: %s", doc.metadata)
+        return docs

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from pathlib import Path
+from datetime import datetime
 
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
@@ -321,7 +322,9 @@ class IndexEventHandler(FileSystemEventHandler):
 
         # Sort updates by modification time to get latest versions
         updates = sorted(
-            existing_updates, key=lambda p: p.stat().st_mtime, reverse=True
+            existing_updates,
+            key=lambda p: datetime.fromtimestamp(p.stat().st_mtime),
+            reverse=True,
         )
         logger.debug(f"Sorted updates: {[str(p) for p in updates]}")
 


### PR DESCRIPTION
Had these unstaged changes, maybe I merged this
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize indexing by using file modification timestamps to skip unchanged files, enhancing efficiency in `indexer.py`, `cli.py`, and `watcher.py`.
> 
>   - **Behavior**:
>     - `Indexer` now uses `last_modified` timestamps to skip unchanged files during indexing in `indexer.py`.
>     - `collect_documents()` in `indexer.py` checks for file modifications using stored timestamps.
>     - `add_documents()` updates document metadata with current timestamps after indexing.
>   - **Functions**:
>     - Added `_normalize_timestamp()` and `_compare_timestamps()` in `indexer.py` for timestamp handling.
>     - Modified `collect_documents()` to include `check_modified` parameter for skipping unchanged files.
>   - **Misc**:
>     - Updated `index()` in `cli.py` to use new document collection logic.
>     - Adjusted logging in `watcher.py` to reflect changes in file processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme-rag&utm_source=github&utm_medium=referral)<sup> for 0b71d3c98bb631d891197fa7c7d186a1feb7c87e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->