### PR TITLE
feat: don't print relevance score by default

### DIFF
--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -364,6 +364,11 @@ def index(
     multiple=True,
     help="Filter results by path pattern (glob). Can be specified multiple times.",
 )
+@click.option(
+    "--print-relevance",
+    is_flag=True,
+    help="Print relevance scores",
+)
 def search(
     query: str,
     paths: list[Path],
@@ -378,6 +383,7 @@ def search(
     embedding_function: str | None,
     device: str | None,
     filter: tuple[str, ...],
+    print_relevance: bool,
 ):
     """Search the index and assemble context."""
     paths = [path.resolve() for path in paths]
@@ -498,7 +504,7 @@ def search(
     if format == "full":
         for i, doc in enumerate(documents):
             # Show relevance info first
-            if distances:
+            if distances and print_relevance:
                 formatter.print_relevance(1 - distances[i])
 
             # Get and format content
@@ -550,7 +556,8 @@ def search(
             console.print(f"\n  {'Total':15} [bold blue]{total:>7.3f}[/bold blue]")
         else:
             # Just show the base relevance score
-            formatter.print_relevance(1 - distances[i])
+            if distances and print_relevance:
+                formatter.print_relevance(1 - distances[i])
 
         # Display preview
         formatter.print_preview(doc)


### PR DESCRIPTION
For post-processing RAG output with an LLM we don't want to influence the LLM by including the relevance score.

See this PR for the post-processing: https://github.com/ErikBjare/gptme/pull/435
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `--print-relevance` flag to `search` command in `gptme_rag/cli.py` to control printing of relevance scores, defaulting to not printing them.
> 
>   - **Behavior**:
>     - Adds `--print-relevance` flag to `search` command in `gptme_rag/cli.py` to control printing of relevance scores.
>     - By default, relevance scores are not printed unless `--print-relevance` is specified.
>   - **Functions**:
>     - Updates `search()` function to include `print_relevance` parameter and conditionally print relevance scores in `get_expanded_content()` and summary view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme-rag&utm_source=github&utm_medium=referral)<sup> for 1aa5797eeafdf0d57604be0011e5021ddf599e1f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->