### PR TITLE
fix(watcher): use resolve() for consistent path handling in on_moved

### DIFF
--- a/gptme_rag/indexing/indexer.py
+++ b/gptme_rag/indexing/indexer.py
@@ -530,6 +530,8 @@ class Indexer:
         Returns:
             bool: True if document matches any path or filter
         """
+        if doc.metadata is None:
+            return False
         source = doc.metadata.get("source", "")
         if not source:
             return False

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -70,6 +70,11 @@ class IndexEventHandler(FileSystemEventHandler):
         time.sleep(self._update_delay)
 
         try:
+            # Check if file still exists (might have been moved/deleted during delay)
+            if not path.exists():
+                logger.debug(f"File no longer exists (likely moved/deleted), skipping: {path}")
+                return
+
             # Read file content first to ensure it's readable
             content = path.read_text()
             canonical_path = str(path.resolve())

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -91,6 +91,9 @@ class IndexEventHandler(FileSystemEventHandler):
                 logger.warning(f"No documents indexed for {path}")
                 return
 
+            # Clear search cache to ensure fresh results for verification
+            self.indexer.cache.clear()
+
             # Verify the update
             logger.debug(f"Verifying update for {canonical_path}")
             results, _, _ = self.indexer.search(content[:100], n_results=1)

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -70,13 +70,14 @@ class IndexEventHandler(FileSystemEventHandler):
         time.sleep(self._update_delay)
 
         try:
-            # Check if file still exists (might have been moved/deleted during delay)
-            if not path.exists():
-                logger.debug(f"File no longer exists (likely moved/deleted), skipping: {path}")
-                return
-
             # Read file content first to ensure it's readable
             content = path.read_text()
+        except FileNotFoundError:
+            # File was moved/deleted during the update delay - this is expected for move events
+            logger.debug(f"File no longer exists (likely moved/deleted), skipping: {path}")
+            return
+        
+        try:
             canonical_path = str(path.resolve())
 
             # Delete old versions

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -102,8 +102,8 @@ class IndexEventHandler(FileSystemEventHandler):
         """Handle file move events."""
         if not event.is_directory:
             logger.info(f"File moved: {event.src_path} -> {event.dest_path}")
-            src_path = Path(event.src_path).absolute()
-            dest_path = Path(event.dest_path).absolute()
+            src_path = Path(event.src_path).resolve()
+            dest_path = Path(event.dest_path).resolve()
 
             # Remove old file from index if it was being tracked
             if self._should_process(event.src_path):

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -410,3 +410,4 @@ class FileWatcher:
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Stop watching when exiting context manager."""
         self.stop()
+

--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -135,6 +135,9 @@ class IndexEventHandler(FileSystemEventHandler):
                         # Index the file
                         self.indexer.index_file(dest_path)
 
+                        # Clear search cache to ensure fresh results for verification
+                        self.indexer.cache.clear()
+
                         # Verify the update with content-based search
                         results, _, _ = self.indexer.search(
                             content[:50]


### PR DESCRIPTION
## Summary

Fix for flaky `test_file_watcher_move` test that was causing CI failures on master.

## Root Cause

The `on_moved` handler was using `.absolute()` for path normalization:
```python
src_path = Path(event.src_path).absolute()
dest_path = Path(event.dest_path).absolute()
```

While the indexer uses `.resolve()` in `_get_valid_files()`:
```python
path = path.resolve()  # Line 1106
```

This inconsistency caused path comparison failures during file move verification, because:
- `.absolute()` makes a path absolute relative to cwd
- `.resolve()` resolves symlinks and returns a canonical absolute path

## Fix

Changed `.absolute()` to `.resolve()` in the `on_moved` handler for consistent path handling.

## Testing

CI was failing with 62/63 tests passing. The `test_file_watcher_move` test should now pass with consistent path resolution.

---
Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `.absolute()` to `.resolve()` in `on_moved()` in `watcher.py` to fix flaky test by ensuring consistent path handling.
> 
>   - **Behavior**:
>     - Change `.absolute()` to `.resolve()` in `on_moved()` in `watcher.py` for consistent path handling.
>     - Fixes flaky `test_file_watcher_move` test by ensuring consistent path resolution.
>   - **Testing**:
>     - CI was failing with 62/63 tests passing; the change should ensure all tests pass consistently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-rag&utm_source=github&utm_medium=referral)<sup> for 0150f3a15fc5d6df192128c9368ef98a72692382. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->