### PR TITLE
fix: dead code, perf, type safety, safer I/O

### DIFF
--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 import os
@@ -402,10 +403,8 @@ def search(
                 console.print(f"❌ Error parsing weights: {e}", style="red")
                 return
 
-        # Temporarily redirect stdout to suppress ChromaDB output
-        stdout = sys.stdout
-        sys.stdout = open(os.devnull, "w")
-        try:
+        # Redirect stdout to suppress ChromaDB output (using context manager for safety)
+        with open(os.devnull, "w") as devnull, contextlib.redirect_stdout(devnull):
             # Initialize indexer with explicit arguments
             # Always use ModernBERT by default for better results
             indexer = Indexer(
@@ -440,9 +439,6 @@ def search(
                 documents, distances, _ = indexer.search(
                     query, n_results=n_results, paths=search_paths, path_filters=filter
                 )
-        finally:
-            sys.stdout.close()
-            sys.stdout = stdout
 
     if not documents:
         console.print("No results found", style="yellow")

--- a/gptme_rag/indexing/document.py
+++ b/gptme_rag/indexing/document.py
@@ -64,11 +64,6 @@ class Document:
             # Process file in chunks
             base_id = str(path.absolute())
             for chunk in processor.process_file(path):
-                # Merge base metadata with chunk metadata
-                chunk_metadata = {
-                    **base_metadata,
-                    **chunk["metadata"],
-                }
                 # Ensure unique chunk IDs by using both index and position
                 chunk_id = f"{base_id}#chunk{chunk['metadata']['chunk_index']}-{chunk['metadata']['chunk_start']}"
                 # Create chunk metadata with chunk-specific fields

--- a/gptme_rag/indexing/document_processor.py
+++ b/gptme_rag/indexing/document_processor.py
@@ -153,7 +153,7 @@ class DocumentProcessor:
             with open(file_path, "rb") as f:
                 chunk = f.read(1024)
                 return b"\x00" in chunk
-        except Exception:
+        except OSError:
             return True
 
     def process_file(

--- a/gptme_rag/query/context_assembler.py
+++ b/gptme_rag/query/context_assembler.py
@@ -64,12 +64,13 @@ class ContextAssembler:
             total_tokens += query_tokens
 
         # Add documents until we hit token limit
+        seen_contents: set[str] = set()
         for doc in documents:
             formatted_doc = self._format_document(doc)
             doc_tokens = self._count_tokens(formatted_doc)
 
-            # check if document content is duplicate
-            if doc.content in [d.content for d in included_docs]:
+            # check if document content is duplicate (O(1) lookup instead of O(n))
+            if doc.content in seen_contents:
                 logger.warning(f"Duplicate document found: {doc.metadata['source']}")
                 continue
 
@@ -80,6 +81,7 @@ class ContextAssembler:
             total_tokens += doc_tokens
             context_parts.append(formatted_doc)
             included_docs.append(doc)
+            seen_contents.add(doc.content)
 
         # Add user query at the end if provided
         if user_query:


### PR DESCRIPTION
## Summary

- **context_assembler**: Replace O(n²) duplicate content check (`doc.content in [d.content for d in included_docs]`) with O(1) set lookup. Matters when assembling many documents.
- **document.py**: Remove dead code — `chunk_metadata` was assigned on line 68, then immediately overwritten on line 75 with a superset of the same data.
- **document_processor**: Catch `OSError` instead of bare `Exception` in `is_binary_file()`. Only I/O errors should trigger the fallback; unexpected errors should propagate.
- **cli.py**: Replace manual `sys.stdout` swap with `contextlib.redirect_stdout`. The old pattern leaked the `/dev/null` file descriptor if an exception occurred between `sys.stdout = open(...)` and the `finally` block.
- **indexer.py**: Fix two pre-existing mypy errors — explicit `list()` conversion for `zip` unpacking, and handle `Optional[str]` doc_id in cache entry construction.

## Test plan

- [x] All 63 existing tests pass
- [x] `ruff check` clean
- [x] `mypy` clean (fixes 2 pre-existing errors)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize duplicate content check, improve code safety, remove dead code, and fix type errors across multiple files.
> 
>   - **Performance**:
>     - Optimize duplicate content check in `assemble_context()` in `context_assembler.py` using O(1) set lookup instead of O(n²) list comprehension.
>   - **Code Safety**:
>     - Replace `sys.stdout` swap with `contextlib.redirect_stdout` in `cli.py` to prevent file descriptor leaks.
>     - Catch `OSError` instead of `Exception` in `is_binary_file()` in `document_processor.py` to handle only I/O errors.
>   - **Dead Code Removal**:
>     - Remove redundant `chunk_metadata` assignment in `from_file()` in `document.py`.
>   - **Type Safety**:
>     - Fix `mypy` errors in `indexer.py` by adding explicit `list()` conversion for `zip` and handling `Optional[str]` for `doc_id`.
>   - **Testing**:
>     - All existing tests pass, `ruff check` and `mypy` are clean.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-rag&utm_source=github&utm_medium=referral)<sup> for bc364456e5d1d5e05d062c6f95d74ff853ccbabc. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->