### PR TITLE
fix(watcher): implement document removal on file deletion

### DIFF
--- a/gptme_rag/indexing/watcher.py
+++ b/gptme_rag/indexing/watcher.py
@@ -52,8 +52,7 @@ class IndexEventHandler(FileSystemEventHandler):
     def on_deleted(self, event: FileSystemEvent) -> None:
         """Handle file deletion events."""
         if not event.is_directory and self._should_process(event.src_path):
-            # TODO: Implement document removal in Indexer
-            logger.info(f"File deleted: {event.src_path}")
+            self._queue_deletion(Path(event.src_path))
 
     def _should_process(self, path: str) -> bool:
         """Check if a file should be processed based on pattern and ignore patterns."""
@@ -64,56 +63,92 @@ class IndexEventHandler(FileSystemEventHandler):
 
     def _queue_update(self, path: Path) -> None:
         """Queue a file for update with debouncing.
-        
+
         Multiple rapid events for the same file are coalesced into a single update.
         """
         resolved_path = path.resolve()
-        
+
         with self._lock:
             if self._should_skip_file(path, set()):
                 return
-            
+
             # Cancel any existing timer for this path
             if resolved_path in self._timers:
                 self._timers[resolved_path].cancel()
-            
+
             # Schedule update after delay (debouncing)
-            timer = Timer(self._update_delay, self._process_update, args=[resolved_path])
+            timer = Timer(
+                self._update_delay, self._process_update, args=[resolved_path]
+            )
             self._timers[resolved_path] = timer
             timer.start()
             logger.debug(f"Queued update for {path} (delay: {self._update_delay}s)")
+
+    def _queue_deletion(self, path: Path) -> None:
+        """Queue a file for deletion from the index with debouncing."""
+        resolved_path = path.resolve()
+
+        with self._lock:
+            # Cancel any pending update timer for this path
+            if resolved_path in self._timers:
+                self._timers[resolved_path].cancel()
+
+            # Schedule deletion after delay (debouncing)
+            timer = Timer(
+                self._update_delay, self._process_deletion, args=[resolved_path]
+            )
+            self._timers[resolved_path] = timer
+            timer.start()
+            logger.debug(f"Queued deletion for {path} (delay: {self._update_delay}s)")
+
+    def _process_deletion(self, path: Path) -> None:
+        """Process a queued file deletion."""
+        with self._lock:
+            self._timers.pop(path, None)
+
+        canonical_path = str(path)
+        logger.info(f"Removing deleted file from index: {canonical_path}")
+
+        try:
+            self.indexer.delete_documents({"source": canonical_path})
+            self.indexer.cache.clear()
+            logger.debug(f"Successfully removed {canonical_path} from index")
+        except Exception as e:
+            logger.error(
+                f"Error removing {canonical_path} from index: {e}", exc_info=True
+            )
 
     def _process_update(self, path: Path) -> None:
         """Process a queued file update."""
         with self._lock:
             # Remove timer reference
             self._timers.pop(path, None)
-        
+
         logger.debug(f"Processing update for {path}")
-        
+
         try:
             if not path.exists():
                 logger.debug(f"File no longer exists, skipping: {path}")
                 return
-            
+
             # Read file content to ensure it's readable
             content = path.read_text()
             canonical_path = str(path)
-            
+
             # Delete old versions
             logger.debug(f"Deleting old versions for {canonical_path}")
             self.indexer.delete_documents({"source": canonical_path})
-            
+
             # Index new content
             logger.debug(f"Indexing new content for {canonical_path}")
             n_indexed = self.indexer.index_file(path)
             if n_indexed == 0:
                 logger.warning(f"No documents indexed for {path}")
                 return
-            
+
             # Clear search cache to ensure fresh results
             self.indexer.cache.clear()
-            
+
             # Verify the update
             logger.debug(f"Verifying update for {canonical_path}")
             results, _, _ = self.indexer.search(content[:100], n_results=1)
@@ -123,7 +158,7 @@ class IndexEventHandler(FileSystemEventHandler):
                 logger.warning(f"Found results but source doesn't match for {path}")
             else:
                 logger.debug(f"Successfully updated {path}")
-                
+
         except FileNotFoundError:
             logger.debug(f"File no longer exists (likely moved/deleted): {path}")
         except Exception as e:
@@ -370,7 +405,7 @@ class IndexEventHandler(FileSystemEventHandler):
         self._pending_updates.clear()
         self._last_update = time.time()
         logger.info("Finished processing updates")
-    
+
     def cancel_pending_updates(self) -> None:
         """Cancel all pending update timers."""
         with self._lock:

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -110,6 +110,66 @@ def test_file_watcher_move(tmp_path, indexer):
         ), "Wrong filename in metadata"
 
 
+def test_file_watcher_delete(tmp_path, indexer):
+    """Test that deleting a file removes it from the index."""
+    test_file = tmp_path / "deleteme.txt"
+
+    with FileWatcher(indexer, [str(tmp_path)], update_delay=0):
+        # Create and verify file is indexed
+        test_file.write_text("Unique deletable content")
+        time.sleep(1)
+
+        results, _, _ = indexer.search("Unique deletable content")
+        assert len(results) == 1, "File should be indexed"
+        assert results[0].metadata["filename"] == test_file.name
+
+        # Delete the file
+        test_file.unlink()
+        time.sleep(1)
+
+        # Clear cache so we get fresh results
+        indexer.cache.clear()
+
+        # Verify file was removed from index
+        results, _, _ = indexer.search("Unique deletable content")
+        assert len(results) == 0, "Deleted file should be removed from index"
+
+
+def test_file_watcher_delete_one_of_many(tmp_path, indexer):
+    """Test that deleting one file doesn't affect other indexed files."""
+    file_a = tmp_path / "keep.txt"
+    file_b = tmp_path / "remove.txt"
+
+    with FileWatcher(indexer, [str(tmp_path)], update_delay=0):
+        # Create two files with very different content
+        file_a.write_text("Alpha bravo charlie delta")
+        file_b.write_text("Xray yankee zulu whiskey")
+        time.sleep(1)
+
+        # Verify both are indexed
+        results_a, _, _ = indexer.search("Alpha bravo charlie delta")
+        assert len(results_a) >= 1
+        results_b, _, _ = indexer.search("Xray yankee zulu whiskey")
+        assert len(results_b) >= 1
+
+        # Delete only file_b
+        file_b.unlink()
+        time.sleep(1)
+        indexer.cache.clear()
+
+        # file_a should still be in the index
+        results_a, _, _ = indexer.search("Alpha bravo charlie delta")
+        assert len(results_a) == 1, "Kept file should still be indexed"
+        assert results_a[0].metadata["filename"] == file_a.name
+
+        # file_b source should not appear in any results
+        all_docs = indexer.list_documents(group_by_source=True)
+        sources = [doc.metadata.get("source", "") for doc in all_docs]
+        assert not any(
+            file_b.name in s for s in sources
+        ), "Deleted file should not appear in index"
+
+
 def test_file_watcher_batch_updates(tmp_path, indexer):
     """Test handling of multiple rapid updates."""
     test_file = tmp_path / "test.txt"


### PR DESCRIPTION
## Summary

- Implements the `on_deleted` handler in `IndexEventHandler` that was previously a TODO stub (just logged the event)
- Deleted files are now properly removed from the ChromaDB index via `delete_documents({"source": path})`
- Uses the same debouncing pattern as file updates to handle rapid deletion events
- Clears the search cache after deletion to ensure stale results aren't returned

## Test plan

- [x] `test_file_watcher_delete` — verifies a deleted file is removed from the index
- [x] `test_file_watcher_delete_one_of_many` — verifies deleting one file doesn't affect other indexed files
- [x] All existing watcher tests still pass (7/7)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements file deletion handling in `IndexEventHandler` to remove documents from the index and clear the search cache, with tests verifying functionality.
> 
>   - **Behavior**:
>     - Implements `on_deleted` in `IndexEventHandler` to remove documents from the index on file deletion.
>     - Uses debouncing for deletion events similar to updates.
>     - Clears search cache after deletion to prevent stale results.
>   - **Functions**:
>     - Adds `_queue_deletion()` and `_process_deletion()` in `watcher.py` for handling file deletions.
>   - **Tests**:
>     - Adds `test_file_watcher_delete` to verify deleted files are removed from the index.
>     - Adds `test_file_watcher_delete_one_of_many` to ensure deleting one file doesn't affect others.
>     - All existing watcher tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-rag&utm_source=github&utm_medium=referral)<sup> for 27eb405a24e8acc8965c37db8c9877886a5084c5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->