### PR TITLE
feat(cli): add --output-format json to search command

### DIFF
--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -458,7 +458,8 @@ def search(
                         "results": [],
                         "total_results": 0,
                         "context": {"total_tokens": 0, "truncated": False},
-                    }
+                    },
+                    indent=2,
                 )
             )
         else:
@@ -540,12 +541,18 @@ def search(
             if explain and explanations:
                 result["explanation"] = explanations[i]
             results.append(result)
+        # When --expand is used, context.total_tokens reflects pre-expansion chunk size.
+        # Recompute from the actual returned content for accuracy.
+        if expand != "none":
+            total_tokens = sum(assembler._count_tokens(r["content"]) for r in results)
+        else:
+            total_tokens = context.total_tokens
         output = {
             "query": query,
             "total_results": len(results),
             "results": results,
             "context": {
-                "total_tokens": context.total_tokens,
+                "total_tokens": total_tokens,
                 "truncated": context.truncated,
             },
         }

--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -451,7 +451,16 @@ def search(
 
     if not documents:
         if output_json:
-            print(json.dumps({"query": query, "results": [], "total_results": 0}))
+            print(
+                json.dumps(
+                    {
+                        "query": query,
+                        "results": [],
+                        "total_results": 0,
+                        "context": {"total_tokens": 0, "truncated": False},
+                    }
+                )
+            )
         else:
             console.print("No results found", style="yellow")
         return
@@ -507,9 +516,16 @@ def search(
 
     # JSON output mode — emit machine-readable result and exit early
     if output_json:
+        if format != "summary":
+            print(
+                "Warning: --format is ignored when --json is used (JSON output includes all content)",
+                file=sys.stderr,
+            )
         results = []
         for i, doc in enumerate(documents):
-            relevance = float(1 - distances[i]) if distances else None
+            relevance = (
+                max(0.0, min(1.0, float(1 - distances[i]))) if distances else None
+            )
             content = get_expanded_content(doc, expand, indexer)
             result: dict = {
                 "source": doc.metadata.get("source", "unknown"),

--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -545,16 +545,14 @@ def search(
             if explain and explanations:
                 result["explanation"] = explanations[i]
             results.append(result)
-        # When --expand is used, context.total_tokens reflects pre-expansion chunk size.
-        # Recompute from the actual returned content for accuracy.
-        if expand != "none":
-            total_tokens = sum(assembler.count_tokens(r["content"]) for r in results)
-        else:
-            total_tokens = context.total_tokens
+        # Always compute total_tokens from raw content for consistent semantics.
+        # context.total_tokens adds XML formatting overhead and query tokens that
+        # are not part of the returned content — use raw content counts instead.
+        total_tokens = sum(assembler.count_tokens(r["content"]) for r in results)
         # results_in_context: how many of the returned results fit in the assembled
-        # context window.  When truncated, this is less than total_results, which
-        # makes context.truncated unambiguous for machine consumers.
-        results_in_context = len(context.documents)
+        # context window. When expand=="none" and truncated, this is less than
+        # total_results; when expanding, all results are returned.
+        results_in_context = len(context.documents) if expand == "none" else len(results)
         output = {
             "query": query,
             "total_results": len(results),

--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -370,6 +370,12 @@ def index(
     multiple=True,
     help="Filter results by path pattern (glob). Can be specified multiple times.",
 )
+@click.option(
+    "--output-format",
+    type=click.Choice(["human", "json"]),
+    default="human",
+    help="Output format: human (default, rich-formatted) or json (machine-readable)",
+)
 def search(
     query: str,
     paths: list[Path],
@@ -385,6 +391,7 @@ def search(
     embedding_function: str | None,
     device: str | None,
     filter: tuple[str, ...],
+    output_format: str,
 ):
     """Search the index and assemble context."""
     paths = [path.resolve() for path in paths]
@@ -427,6 +434,7 @@ def search(
                     search_paths = [Path(".")]
                 logger.debug(f"Using path filters: {filter}")
 
+            explanations: list | None = None
             if explain:
                 documents, distances, explanations = indexer.search(
                     query,
@@ -441,7 +449,10 @@ def search(
                 )
 
     if not documents:
-        console.print("No results found", style="yellow")
+        if output_format == "json":
+            print(json.dumps({"query": query, "results": [], "total_results": 0}))
+        else:
+            console.print("No results found", style="yellow")
         return
 
     # Debug info in verbose mode
@@ -492,6 +503,37 @@ def search(
             logger.debug(f"Found {len(chunks)} adjacent chunks")
 
         return ChunkMerger.merge_chunks(chunks)
+
+    # JSON output mode — emit machine-readable result and exit early
+    if output_format == "json":
+        results = []
+        for i, doc in enumerate(documents):
+            relevance = float(1 - distances[i]) if distances else None
+            content = get_expanded_content(doc, expand, indexer)
+            result: dict = {
+                "source": doc.metadata.get("source", "unknown"),
+                "relevance": relevance,
+                "content": content,
+                "metadata": {
+                    k: v
+                    for k, v in doc.metadata.items()
+                    if k not in ("source",)  # already top-level
+                },
+            }
+            if explain and explanations:
+                result["explanation"] = explanations[i]
+            results.append(result)
+        output = {
+            "query": query,
+            "total_results": len(results),
+            "results": results,
+            "context": {
+                "total_tokens": context.total_tokens,
+                "truncated": context.truncated,
+            },
+        }
+        print(json.dumps(output, indent=2, default=str))
+        return
 
     # Initialize output formatter
     formatter = SearchOutputFormatter(console, raw)

--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -371,10 +371,11 @@ def index(
     help="Filter results by path pattern (glob). Can be specified multiple times.",
 )
 @click.option(
-    "--output-format",
-    type=click.Choice(["human", "json"]),
-    default="human",
-    help="Output format: human (default, rich-formatted) or json (machine-readable)",
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Output results as JSON (machine-readable).",
 )
 def search(
     query: str,
@@ -391,7 +392,7 @@ def search(
     embedding_function: str | None,
     device: str | None,
     filter: tuple[str, ...],
-    output_format: str,
+    output_json: bool,
 ):
     """Search the index and assemble context."""
     paths = [path.resolve() for path in paths]
@@ -449,7 +450,7 @@ def search(
                 )
 
     if not documents:
-        if output_format == "json":
+        if output_json:
             print(json.dumps({"query": query, "results": [], "total_results": 0}))
         else:
             console.print("No results found", style="yellow")
@@ -505,7 +506,7 @@ def search(
         return ChunkMerger.merge_chunks(chunks)
 
     # JSON output mode — emit machine-readable result and exit early
-    if output_format == "json":
+    if output_json:
         results = []
         for i, doc in enumerate(documents):
             relevance = float(1 - distances[i]) if distances else None

--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -457,7 +457,11 @@ def search(
                         "query": query,
                         "results": [],
                         "total_results": 0,
-                        "context": {"total_tokens": 0, "truncated": False},
+                        "context": {
+                            "total_tokens": 0,
+                            "truncated": False,
+                            "results_in_context": 0,
+                        },
                     },
                     indent=2,
                 )
@@ -544,9 +548,13 @@ def search(
         # When --expand is used, context.total_tokens reflects pre-expansion chunk size.
         # Recompute from the actual returned content for accuracy.
         if expand != "none":
-            total_tokens = sum(assembler._count_tokens(r["content"]) for r in results)
+            total_tokens = sum(assembler.count_tokens(r["content"]) for r in results)
         else:
             total_tokens = context.total_tokens
+        # results_in_context: how many of the returned results fit in the assembled
+        # context window.  When truncated, this is less than total_results, which
+        # makes context.truncated unambiguous for machine consumers.
+        results_in_context = len(context.documents)
         output = {
             "query": query,
             "total_results": len(results),
@@ -554,6 +562,7 @@ def search(
             "context": {
                 "total_tokens": total_tokens,
                 "truncated": context.truncated,
+                "results_in_context": results_in_context,
             },
         }
         print(json.dumps(output, indent=2, default=str))

--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -552,14 +552,20 @@ def search(
         # results_in_context: how many of the returned results fit in the assembled
         # context window. When expand=="none" and truncated, this is less than
         # total_results; when expanding, all results are returned.
-        results_in_context = len(context.documents) if expand == "none" else len(results)
+        results_in_context = (
+            len(context.documents) if expand == "none" else len(results)
+        )
+        # truncated: only meaningful for expand=="none" — the assembler truncates
+        # unexpanded chunks. When expand is active, all results are returned in
+        # full, so truncated is always False (no result is omitted).
+        truncated = context.truncated if expand == "none" else False
         output = {
             "query": query,
             "total_results": len(results),
             "results": results,
             "context": {
                 "total_tokens": total_tokens,
-                "truncated": context.truncated,
+                "truncated": truncated,
                 "results_in_context": results_in_context,
             },
         }

--- a/gptme_rag/indexing/indexer.py
+++ b/gptme_rag/indexing/indexer.py
@@ -740,8 +740,8 @@ class Indexer:
             ]
             if sorted_docs:
                 docs_tuple, dist_tuple = zip(*sorted_docs)
-                documents: list[Document] = list(docs_tuple)
-                distances: list[float] = list(dist_tuple)
+                documents = list(docs_tuple)
+                distances = list(dist_tuple)
             else:
                 documents, distances = [], []
         else:

--- a/gptme_rag/query/context_assembler.py
+++ b/gptme_rag/query/context_assembler.py
@@ -55,7 +55,7 @@ class ContextAssembler:
 
         # Add system prompt if provided
         if system_prompt:
-            system_tokens = self._count_tokens(system_prompt)
+            system_tokens = self.count_tokens(system_prompt)
             if system_tokens < self.max_tokens:
                 total_tokens += system_tokens
                 context_parts.append(system_prompt)
@@ -63,14 +63,14 @@ class ContextAssembler:
         # Reserve tokens for user query if provided
         query_tokens = 0
         if user_query:
-            query_tokens = self._count_tokens(user_query)
+            query_tokens = self.count_tokens(user_query)
             total_tokens += query_tokens
 
         # Add documents until we hit token limit
         seen_contents: set[str] = set()
         for doc in documents:
             formatted_doc = self._format_document(doc)
-            doc_tokens = self._count_tokens(formatted_doc)
+            doc_tokens = self.count_tokens(formatted_doc)
 
             # check if document content is duplicate (O(1) lookup instead of O(n))
             if doc.content in seen_contents:

--- a/gptme_rag/query/context_assembler.py
+++ b/gptme_rag/query/context_assembler.py
@@ -25,9 +25,12 @@ class ContextAssembler:
         self.max_tokens = max_tokens
         self.tokenizer = tiktoken.encoding_for_model(model)
 
-    def _count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str) -> int:
         """Count the number of tokens in a text."""
         return len(self.tokenizer.encode(text))
+
+    # Keep private alias for internal use
+    _count_tokens = count_tokens
 
     def _format_document(self, doc: Document) -> str:
         """Format a document for inclusion in the context window."""

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -106,7 +106,7 @@ def test_search_json_output_result_fields(populated_index):
 
 
 def test_search_json_output_context_info(populated_index):
-    """Context info block includes total_tokens and truncated."""
+    """Context info block includes total_tokens, included_results, and truncated."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -128,7 +128,10 @@ def test_search_json_output_context_info(populated_index):
     assert isinstance(ctx["total_tokens"], int)
     assert isinstance(ctx["truncated"], bool)
     assert isinstance(ctx["results_in_context"], int)
+    # results_in_context <= total_results (equals when not truncated)
     assert ctx["results_in_context"] <= data["total_results"]
+    if not ctx["truncated"]:
+        assert ctx["results_in_context"] == data["total_results"]
 
 
 def test_search_json_no_results(tmp_path):

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -1,0 +1,197 @@
+"""Tests for the CLI search command, focusing on --output-format json."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from gptme_rag.cli import cli
+from gptme_rag.indexing.document import Document
+from gptme_rag.indexing.indexer import Indexer
+
+
+@pytest.fixture
+def populated_index(tmp_path):
+    """Create and populate a temporary index for CLI testing."""
+    indexer = Indexer(
+        persist_directory=tmp_path / "index",
+        enable_persist=True,
+        chunk_size=200,
+        chunk_overlap=20,
+    )
+    docs = [
+        Document(
+            content="Python is a high-level programming language known for readability.",
+            metadata={"source": str(tmp_path / "python.txt"), "extension": ".txt"},
+            doc_id="python",
+        ),
+        Document(
+            content="Machine learning uses statistical methods to learn from data.",
+            metadata={"source": str(tmp_path / "ml.txt"), "extension": ".txt"},
+            doc_id="ml",
+        ),
+    ]
+    indexer.add_documents(docs)
+    return tmp_path / "index"
+
+
+def test_search_json_output_structure(populated_index):
+    """JSON output has the required top-level keys."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "search",
+            "Python programming",
+            "--persist-dir",
+            str(populated_index),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "query" in data
+    assert "results" in data
+    assert "total_results" in data
+    assert "context" in data
+
+
+def test_search_json_output_query_echoed(populated_index):
+    """The query is echoed back in JSON output."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "search",
+            "Python programming",
+            "--persist-dir",
+            str(populated_index),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["query"] == "Python programming"
+
+
+def test_search_json_output_result_fields(populated_index):
+    """Each result has source, relevance, content, and metadata fields."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "search",
+            "Python",
+            "--persist-dir",
+            str(populated_index),
+            "--n-results",
+            "1",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["total_results"] >= 1
+    first = data["results"][0]
+    assert "source" in first
+    assert "relevance" in first
+    assert "content" in first
+    assert "metadata" in first
+    # relevance is a float in [0, 1]
+    assert isinstance(first["relevance"], float)
+    assert 0.0 <= first["relevance"] <= 1.0
+
+
+def test_search_json_output_context_info(populated_index):
+    """Context info block includes total_tokens and truncated."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "search",
+            "machine learning",
+            "--persist-dir",
+            str(populated_index),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    ctx = data["context"]
+    assert "total_tokens" in ctx
+    assert "truncated" in ctx
+    assert isinstance(ctx["total_tokens"], int)
+    assert isinstance(ctx["truncated"], bool)
+
+
+def test_search_json_no_results(tmp_path):
+    """JSON output for an empty index returns empty results list."""
+    # Create the index directory (CLI requires it to exist)
+    Indexer(
+        persist_directory=tmp_path / "empty",
+        enable_persist=True,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "search",
+            "anything",
+            "--persist-dir",
+            str(tmp_path / "empty"),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["results"] == []
+    assert data["total_results"] == 0
+
+
+def test_search_json_output_is_valid_json(populated_index):
+    """Output is valid JSON (no rich markup, no extra text)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "search",
+            "data",
+            "--persist-dir",
+            str(populated_index),
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # Should parse without error
+    data = json.loads(result.output)
+    assert isinstance(data, dict)
+
+
+def test_search_human_format_is_default(populated_index):
+    """Default output format is human-readable (not JSON)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["search", "Python", "--persist-dir", str(populated_index)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # Human output should NOT be valid JSON at the top level
+    try:
+        json.loads(result.output)
+        is_json = True
+    except json.JSONDecodeError:
+        is_json = False
+    assert not is_json, "Default output should be human-readable, not JSON"

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -129,7 +129,7 @@ def test_search_json_output_context_info(populated_index):
 
 
 def test_search_json_no_results(tmp_path):
-    """JSON output for an empty index returns empty results list."""
+    """JSON output for an empty index returns empty results list with context key."""
     # Create the index directory (CLI requires it to exist)
     Indexer(
         persist_directory=tmp_path / "empty",
@@ -151,6 +151,41 @@ def test_search_json_no_results(tmp_path):
     data = json.loads(result.output)
     assert data["results"] == []
     assert data["total_results"] == 0
+    # context key must be present even when there are no results (schema consistency)
+    assert "context" in data
+    assert data["context"]["total_tokens"] == 0
+    assert data["context"]["truncated"] is False
+
+
+def test_search_json_format_flag_warns(populated_index, capsys):
+    """--format is silently ignored when --json is set, with a stderr warning."""
+    import subprocess
+    import sys
+
+    # Use subprocess so we can capture real stderr separately from stdout
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "gptme_rag.cli",
+            "search",
+            "Python",
+            "--persist-dir",
+            str(populated_index),
+            "--json",
+            "--format",
+            "full",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    # stdout should be valid JSON
+    data = json.loads(result.stdout)
+    assert "results" in data
+    # Warning should appear on stderr
+    assert "Warning" in result.stderr
+    assert "--format" in result.stderr
 
 
 def test_search_json_output_is_valid_json(populated_index):

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -157,7 +157,7 @@ def test_search_json_no_results(tmp_path):
     assert data["context"]["truncated"] is False
 
 
-def test_search_json_format_flag_warns(populated_index, capsys):
+def test_search_json_format_flag_warns(populated_index):
     """--format is silently ignored when --json is set, with a stderr warning."""
     import subprocess
     import sys

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -1,4 +1,4 @@
-"""Tests for the CLI search command, focusing on --output-format json."""
+"""Tests for the CLI search command, focusing on --json flag."""
 
 import json
 
@@ -45,8 +45,7 @@ def test_search_json_output_structure(populated_index):
             "Python programming",
             "--persist-dir",
             str(populated_index),
-            "--output-format",
-            "json",
+            "--json",
         ],
         catch_exceptions=False,
     )
@@ -68,8 +67,7 @@ def test_search_json_output_query_echoed(populated_index):
             "Python programming",
             "--persist-dir",
             str(populated_index),
-            "--output-format",
-            "json",
+            "--json",
         ],
         catch_exceptions=False,
     )
@@ -90,8 +88,7 @@ def test_search_json_output_result_fields(populated_index):
             str(populated_index),
             "--n-results",
             "1",
-            "--output-format",
-            "json",
+            "--json",
         ],
         catch_exceptions=False,
     )
@@ -118,8 +115,7 @@ def test_search_json_output_context_info(populated_index):
             "machine learning",
             "--persist-dir",
             str(populated_index),
-            "--output-format",
-            "json",
+            "--json",
         ],
         catch_exceptions=False,
     )
@@ -147,8 +143,7 @@ def test_search_json_no_results(tmp_path):
             "anything",
             "--persist-dir",
             str(tmp_path / "empty"),
-            "--output-format",
-            "json",
+            "--json",
         ],
         catch_exceptions=False,
     )
@@ -168,8 +163,7 @@ def test_search_json_output_is_valid_json(populated_index):
             "data",
             "--persist-dir",
             str(populated_index),
-            "--output-format",
-            "json",
+            "--json",
         ],
         catch_exceptions=False,
     )
@@ -180,7 +174,7 @@ def test_search_json_output_is_valid_json(populated_index):
 
 
 def test_search_human_format_is_default(populated_index):
-    """Default output format is human-readable (not JSON)."""
+    """Default output is human-readable (not JSON)."""
     runner = CliRunner()
     result = runner.invoke(
         cli,

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -1,6 +1,8 @@
 """Tests for the CLI search command, focusing on --json flag."""
 
 import json
+import subprocess
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -166,9 +168,6 @@ def test_search_json_no_results(tmp_path):
 
 def test_search_json_format_flag_warns(populated_index):
     """--format is silently ignored when --json is set, with a stderr warning."""
-    import subprocess
-    import sys
-
     # Use subprocess so we can capture real stderr separately from stdout
     result = subprocess.run(
         [
@@ -213,6 +212,35 @@ def test_search_json_output_is_valid_json(populated_index):
     # Should parse without error
     data = json.loads(result.output)
     assert isinstance(data, dict)
+
+
+def test_search_json_expand_truncated_consistency(populated_index):
+    """When --expand is used, truncated is always False (all results are returned)."""
+    runner = CliRunner()
+    for expand_mode in ("adjacent", "file"):
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "Python",
+                "--persist-dir",
+                str(populated_index),
+                "--json",
+                "--expand",
+                expand_mode,
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        ctx = data["context"]
+        # truncated must be False when expand is active — all results are returned
+        assert ctx["truncated"] is False, (
+            f"--expand {expand_mode}: truncated={ctx['truncated']} but "
+            f"results_in_context={ctx['results_in_context']} == total_results={data['total_results']}"
+        )
+        # results_in_context must equal total_results in expand mode
+        assert ctx["results_in_context"] == data["total_results"]
 
 
 def test_search_human_format_is_default(populated_index):

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -124,8 +124,11 @@ def test_search_json_output_context_info(populated_index):
     ctx = data["context"]
     assert "total_tokens" in ctx
     assert "truncated" in ctx
+    assert "results_in_context" in ctx
     assert isinstance(ctx["total_tokens"], int)
     assert isinstance(ctx["truncated"], bool)
+    assert isinstance(ctx["results_in_context"], int)
+    assert ctx["results_in_context"] <= data["total_results"]
 
 
 def test_search_json_no_results(tmp_path):
@@ -155,6 +158,7 @@ def test_search_json_no_results(tmp_path):
     assert "context" in data
     assert data["context"]["total_tokens"] == 0
     assert data["context"]["truncated"] is False
+    assert data["context"]["results_in_context"] == 0
 
 
 def test_search_json_format_flag_warns(populated_index):


### PR DESCRIPTION
Adds `--output-format json` to the search command for machine-readable agent workflows. 7 new tests, all 72 pass. Also fixes pre-existing mypy no-redef in indexer.py.