### PR TITLE
fix(cli): align truncated flag with content deduplication

### DIFF
--- a/gptme_rag/cli.py
+++ b/gptme_rag/cli.py
@@ -555,10 +555,16 @@ def search(
         results_in_context = (
             len(context.documents) if expand == "none" else len(results)
         )
-        # truncated: only meaningful for expand=="none" — the assembler truncates
-        # unexpanded chunks. When expand is active, all results are returned in
-        # full, so truncated is always False (no result is omitted).
-        truncated = context.truncated if expand == "none" else False
+        # truncated: indicates some results were excluded from the context.
+        # Covers both token-limit truncation (context.truncated) and content
+        # deduplication by assemble_context (which silently drops duplicates
+        # without setting context.truncated). When expand is active, all results
+        # are returned in full, so truncated is always False.
+        truncated = (
+            (context.truncated or len(context.documents) < len(results))
+            if expand == "none"
+            else False
+        )
         output = {
             "query": query,
             "total_results": len(results),

--- a/gptme_rag/query/context_assembler.py
+++ b/gptme_rag/query/context_assembler.py
@@ -29,9 +29,6 @@ class ContextAssembler:
         """Count the number of tokens in a text."""
         return len(self.tokenizer.encode(text))
 
-    # Keep private alias for internal use
-    _count_tokens = count_tokens
-
     def _format_document(self, doc: Document) -> str:
         """Format a document for inclusion in the context window."""
         return doc.format_xml()

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -243,6 +243,61 @@ def test_search_json_expand_truncated_consistency(populated_index):
         assert ctx["results_in_context"] == data["total_results"]
 
 
+def test_search_json_truncated_on_dedup(tmp_path):
+    """When assemble_context deduplicates chunks, truncated reflects the drop."""
+    index_dir = tmp_path / "dedup_index"
+    indexer = Indexer(
+        persist_directory=index_dir,
+        enable_persist=True,
+        # Large chunk size to avoid splitting — each doc becomes one chunk
+        chunk_size=500,
+        chunk_overlap=0,
+    )
+    # Two documents with identical content but different sources
+    shared_content = "Duplicate content about Python programming and data analysis."
+    docs = [
+        Document(
+            content=shared_content,
+            metadata={"source": str(tmp_path / "file_a.txt"), "extension": ".txt"},
+            doc_id="dup_a",
+        ),
+        Document(
+            content=shared_content,
+            metadata={"source": str(tmp_path / "file_b.txt"), "extension": ".txt"},
+            doc_id="dup_b",
+        ),
+    ]
+    indexer.add_documents(docs)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "search",
+            "Python programming",
+            "--persist-dir",
+            str(index_dir),
+            "--n-results",
+            "10",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    ctx = data["context"]
+    # ChromaDB may return both duplicates as results
+    if data["total_results"] > 1 and ctx["results_in_context"] < data["total_results"]:
+        # The dedup dropped results — truncated must be True
+        assert ctx["truncated"] is True, (
+            f"results_in_context={ctx['results_in_context']} < "
+            f"total_results={data['total_results']} but truncated=False"
+        )
+    # The invariant from test_search_json_output_context_info still holds:
+    # if not truncated, results_in_context == total_results
+    if not ctx["truncated"]:
+        assert ctx["results_in_context"] == data["total_results"]
+
+
 def test_search_human_format_is_default(populated_index):
     """Default output is human-readable (not JSON)."""
     runner = CliRunner()

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -285,17 +285,21 @@ def test_search_json_truncated_on_dedup(tmp_path):
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
     ctx = data["context"]
-    # ChromaDB may return both duplicates as results
-    if data["total_results"] > 1 and ctx["results_in_context"] < data["total_results"]:
-        # The dedup dropped results — truncated must be True
-        assert ctx["truncated"] is True, (
-            f"results_in_context={ctx['results_in_context']} < "
-            f"total_results={data['total_results']} but truncated=False"
-        )
-    # The invariant from test_search_json_output_context_info still holds:
-    # if not truncated, results_in_context == total_results
-    if not ctx["truncated"]:
-        assert ctx["results_in_context"] == data["total_results"]
+    # Both docs have distinct IDs (dup_a, dup_b) so ChromaDB stores and returns
+    # both — the indexer deduplicates by ID only, not by content.
+    assert data["total_results"] == 2, (
+        f"Expected both duplicate docs to be returned by ChromaDB, "
+        f"got total_results={data['total_results']}"
+    )
+    # assemble_context sees identical content and drops the second doc
+    assert (
+        ctx["results_in_context"] == 1
+    ), f"Expected dedup to keep only 1 doc, got results_in_context={ctx['results_in_context']}"
+    # The fix: truncated must be True when dedup dropped results
+    assert ctx["truncated"] is True, (
+        f"results_in_context={ctx['results_in_context']} < "
+        f"total_results={data['total_results']} but truncated=False"
+    )
 
 
 def test_search_human_format_is_default(populated_index):


### PR DESCRIPTION
## Summary

Follow-up fixes from Greptile review of PR #20 (scored 4/5):

- **Fix truncated/results_in_context inconsistency**: When `assemble_context` deduplicates chunks (identical content from different sources), `truncated` now correctly reflects the drop. Previously `truncated=False` with `results_in_context < total_results` was possible, confusing machine consumers.
- **Remove dead `_count_tokens` alias**: All callers now use the public `count_tokens` method directly. The private alias with its misleading comment was dead code.
- **Add dedup test**: `test_search_json_truncated_on_dedup` exercises the duplicate-content path and verifies the invariant holds.

## Test plan

- [x] All 10 CLI search tests pass (including new dedup test)
- [x] Existing invariant test (`test_search_json_output_context_info` lines 135-136) continues to pass