### PR TITLE
feat(mcp): add rag_assemble_context tool for agent-ready context assembly

### DIFF
--- a/gptme_rag/mcp_server.py
+++ b/gptme_rag/mcp_server.py
@@ -39,6 +39,75 @@ def _format_results(
     return out
 
 
+def _assemble_context(
+    documents: list,
+    scores: list[float],
+    query: str,
+    max_context_chars: int = 8000,
+) -> str:
+    """Assemble a coherent Markdown context block from search results.
+
+    Produces a formatted block suitable for direct injection into an agent's
+    system prompt or context window. Results are deduplicated by source,
+    ordered by relevance, and trimmed to fit within ``max_context_chars``.
+
+    Args:
+        documents: ChromaDB document list from ``Indexer.search``.
+        scores: Distance scores (lower = better).
+        query: The original query (for the header).
+        max_context_chars: Soft cap on total output characters (default 8000).
+
+    Returns:
+        Markdown-formatted context block.
+    """
+    max_chars_per_doc = 3000  # generous per-doc limit for context assembly
+    results = _format_results(documents, scores, max_chars_per_doc=max_chars_per_doc)
+
+    # Deduplicate by source (keep highest-scoring entry per source file)
+    seen_sources: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for entry in results:
+        source = entry["source"]
+        if source and source in seen_sources:
+            continue
+        if source:
+            seen_sources.add(source)
+        deduped.append(entry)
+
+    # Build sections
+    lines: list[str] = []
+    header = f'## Retrieved Context for: "{query}"'
+    lines.append(header)
+    lines.append("")
+    lines.append(f"*{len(deduped)} relevant document(s) found.*")
+    lines.append("")
+
+    current_chars = len(header) + len(lines[1]) + len(lines[2]) + 1
+
+    for i, entry in enumerate(deduped):
+        source = entry["source"] or "(unknown)"
+        score_pct = round(entry["score"] * 100)
+        filename = Path(source).name if source else "(unknown)"
+        section = (
+            f"### [{score_pct}% relevant] {filename}\n"
+            f"*Source: {source}*\n\n"
+            f"{entry['content']}\n\n"
+        )
+        # Always include at least the first result; truncate subsequent ones.
+        if i > 0 and current_chars + len(section) > max_context_chars:
+            remaining = len(deduped) - i
+            if remaining > 0:
+                lines.append(
+                    f"*({remaining} more document(s) omitted — "
+                    f"context limit reached)*\n"
+                )
+            break
+        lines.append(section)
+        current_chars += len(section)
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def build_server(persist_dir: Path | None = None) -> Any:
     """Build the MCP server instance.
 
@@ -90,6 +159,36 @@ def build_server(persist_dir: Path | None = None) -> Any:
         indexer = _get_indexer(persist_dir)
         documents, scores, _ = indexer.search(query=query, n_results=top_k)
         return _format_results(documents, scores)
+
+    @server.tool()
+    def rag_assemble_context(
+        query: str,
+        top_k: int = 5,
+        max_context_chars: int = 8000,
+        persist_dir: str | None = None,
+    ) -> str:
+        """Search the gptme-rag index and assemble results into a coherent
+        Markdown context block suitable for direct injection into an agent's
+        prompt or context window.
+
+        Use this instead of ``rag_query`` when you want a single ready-to-use
+        context block rather than raw structured results.
+
+        Args:
+            query: Natural-language search query.
+            top_k: Maximum number of results (default 5, capped at 50).
+            max_context_chars: Soft cap on output characters (default 8000).
+            persist_dir: Optional override for the index directory.
+
+        Returns:
+            Formatted Markdown block with deduplicated, relevance-ordered results.
+        """
+        top_k = max(1, min(int(top_k), 50))
+        indexer = _get_indexer(persist_dir)
+        documents, scores, _ = indexer.search(query=query, n_results=top_k)
+        return _assemble_context(
+            documents, scores, query, max_context_chars=max_context_chars
+        )
 
     @server.tool()
     def rag_index_status(persist_dir: str | None = None) -> dict[str, Any]:

--- a/gptme_rag/mcp_server.py
+++ b/gptme_rag/mcp_server.py
@@ -7,8 +7,6 @@ existing gptme-rag index without going through the CLI.
 This is a v1 prototype — see ``gptme/gptme-rag#22`` for scope and roadmap.
 """
 
-from __future__ import annotations
-
 import logging
 from pathlib import Path
 from typing import Any
@@ -82,11 +80,9 @@ def _assemble_context(
     lines.append(f"*{len(deduped)} relevant document(s) found.*")
     lines.append("")
 
-    current_chars = len(header) + len(lines[1]) + len(lines[2]) + 1
-
     for i, entry in enumerate(deduped):
         source = entry["source"] or "(unknown)"
-        score_pct = round(entry["score"] * 100)
+        score_pct = max(0, min(100, round(entry["score"] * 100)))
         filename = Path(source).name if source else "(unknown)"
         section = (
             f"### [{score_pct}% relevant] {filename}\n"
@@ -94,7 +90,8 @@ def _assemble_context(
             f"{entry['content']}\n\n"
         )
         # Always include at least the first result; truncate subsequent ones.
-        if i > 0 and current_chars + len(section) > max_context_chars:
+        candidate = "\n".join([*lines, section]).rstrip() + "\n"
+        if i > 0 and len(candidate) > max_context_chars:
             remaining = len(deduped) - i
             if remaining > 0:
                 lines.append(
@@ -103,7 +100,6 @@ def _assemble_context(
                 )
             break
         lines.append(section)
-        current_chars += len(section)
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -88,6 +88,28 @@ def test_assemble_context_includes_header_and_counts():
     assert "Hello world." in output
 
 
+def test_assemble_context_clamps_relevance_percentage():
+    """_assemble_context should keep displayed relevance percentages sane."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    poor_match = SimpleNamespace(
+        content="Low relevance.", metadata={"source": "/tmp/low.md"}
+    )
+    impossible_match = SimpleNamespace(
+        content="High relevance.", metadata={"source": "/tmp/high.md"}
+    )
+
+    output = _assemble_context(
+        [poor_match, impossible_match],
+        [1.5, -0.5],
+        "test",
+    )
+    assert "[0% relevant] low.md" in output
+    assert "[100% relevant] high.md" in output
+
+
 def test_assemble_context_respects_max_chars():
     """_assemble_context should truncate when max_context_chars is hit."""
     from types import SimpleNamespace
@@ -102,6 +124,24 @@ def test_assemble_context_respects_max_chars():
     assert "second.md" not in output
     assert "omitted" in output.lower()
     assert "1 more document" in output
+
+
+def test_assemble_context_cap_uses_rendered_markdown_length():
+    """_assemble_context should measure the actual rendered Markdown output."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    doc1 = SimpleNamespace(content="A", metadata={"source": "/tmp/first.md"})
+    doc2 = SimpleNamespace(content="B" * 200, metadata={"source": "/tmp/second.md"})
+    first_only = _assemble_context([doc1], [0.1], "test")
+    omission = "*(1 more document(s) omitted — context limit reached)*\n"
+    cap = len(first_only) + len(omission) + 5
+
+    output = _assemble_context([doc1, doc2], [0.1, 0.2], "test", max_context_chars=cap)
+    assert "first.md" in output
+    assert "second.md" not in output
+    assert len(output) <= cap
 
 
 def test_assemble_context_handles_missing_source():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -51,6 +51,71 @@ def test_format_results_handles_missing_metadata():
     assert out[0]["metadata"] == {}
 
 
+def test_assemble_context_deduplicates_by_source():
+    """_assemble_context should keep only the best entry per source file."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    doc_a = SimpleNamespace(
+        content="Content from file A.", metadata={"source": "/tmp/a.md"}
+    )
+    doc_b = SimpleNamespace(
+        content="Content from file B.", metadata={"source": "/tmp/b.md"}
+    )
+    doc_a2 = SimpleNamespace(
+        content="Another chunk from file A.", metadata={"source": "/tmp/a.md"}
+    )
+
+    # a.md appears twice — only the first (higher-ranked) entry should survive
+    output = _assemble_context([doc_a, doc_b, doc_a2], [0.1, 0.3, 0.5], "test query")
+    assert "file A." in output
+    assert "file B." in output
+    assert "Another chunk" not in output  # deduped out
+
+
+def test_assemble_context_includes_header_and_counts():
+    """_assemble_context should include a query header and document count."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    doc = SimpleNamespace(content="Hello world.", metadata={"source": "/tmp/x.md"})
+    output = _assemble_context([doc], [0.2], "find hello")
+    assert 'Retrieved Context for: "find hello"' in output
+    assert "1 relevant document(s) found" in output
+    assert "[80% relevant]" in output  # 1.0 - 0.2 = 0.8
+    assert "Hello world." in output
+
+
+def test_assemble_context_respects_max_chars():
+    """_assemble_context should truncate when max_context_chars is hit."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    # Two long docs — cap is tight enough to truncate after the first
+    doc1 = SimpleNamespace(content="A" * 2000, metadata={"source": "/tmp/first.md"})
+    doc2 = SimpleNamespace(content="B" * 2000, metadata={"source": "/tmp/second.md"})
+    output = _assemble_context([doc1, doc2], [0.1, 0.2], "test", max_context_chars=1000)
+    assert "first.md" in output
+    assert "second.md" not in output
+    assert "omitted" in output.lower()
+    assert "1 more document" in output
+
+
+def test_assemble_context_handles_missing_source():
+    """_assemble_context should not crash on docs without metadata."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    doc = SimpleNamespace(content="No metadata here.", metadata=None)
+    output = _assemble_context([doc], [0.5], "test")
+    assert "No metadata here." in output
+    assert "(unknown)" in output
+
+
 def test_cli_mcp_command_registered():
     """The `gptme-rag mcp` subcommand should be discoverable via Click."""
     from gptme_rag.cli import cli


### PR DESCRIPTION
## What

Adds a new `rag_assemble_context` MCP tool that assembles search results into a coherent Markdown context block suitable for direct injection into an agent's prompt or context window.

**The gap this fills**: `rag_query` returns raw JSON chunks — useful for programmatic consumers but awkward for agents that just want to inject context. `rag_assemble_context` returns a single formatted block with deduplication, relevance ordering, source attribution, and context-length awareness.

## Behavior

- **Deduplication**: keeps only the highest-scoring chunk per source file
- **Always-at-least-one**: the first result is always included, even if it exceeds `max_context_chars`
- **Truncation**: subsequent results are omitted with a count when the char limit would be exceeded
- **Format**: Markdown with relevance percentages, source paths, and content

## Changes

- `gptme_rag/mcp_server.py`: +99 lines (`_assemble_context` helper + `rag_assemble_context` tool)
- `tests/test_mcp_server.py`: +73 lines (4 new tests)

## Testing

All 13 tests pass (8 fast + 5 slow end-to-end with real ChromaDB):

```
uv run pytest tests/test_mcp_server.py -v
```

Closes the v1.1 deferred item in [ErikBjare/bob idea #208](https://github.com/ErikBjare/bob/blob/master/knowledge/strategic/idea-backlog.md).
