### PR TITLE
refactor(mcp): extract _assemble_context_from_indexer helper

### DIFF
--- a/gptme_rag/mcp_server.py
+++ b/gptme_rag/mcp_server.py
@@ -104,6 +104,23 @@ def _assemble_context(
     return "\n".join(lines).rstrip() + "\n"
 
 
+def _assemble_context_from_indexer(
+    indexer: Any,
+    query: str,
+    top_k: int = 5,
+    max_context_chars: int = 8000,
+) -> str:
+    """Search an indexer and assemble the results into prompt-ready Markdown."""
+    top_k = max(1, min(int(top_k), 50))
+    documents, scores, _ = indexer.search(query=query, n_results=top_k)
+    return _assemble_context(
+        documents,
+        scores,
+        query,
+        max_context_chars=max_context_chars,
+    )
+
+
 def build_server(persist_dir: Path | None = None) -> Any:
     """Build the MCP server instance.
 
@@ -179,11 +196,11 @@ def build_server(persist_dir: Path | None = None) -> Any:
         Returns:
             Formatted Markdown block with deduplicated, relevance-ordered results.
         """
-        top_k = max(1, min(int(top_k), 50))
-        indexer = _get_indexer(persist_dir)
-        documents, scores, _ = indexer.search(query=query, n_results=top_k)
-        return _assemble_context(
-            documents, scores, query, max_context_chars=max_context_chars
+        return _assemble_context_from_indexer(
+            _get_indexer(persist_dir),
+            query,
+            top_k=top_k,
+            max_context_chars=max_context_chars,
         )
 
     @server.tool()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -156,6 +156,79 @@ def test_assemble_context_handles_missing_source():
     assert "(unknown)" in output
 
 
+def test_rag_assemble_context_tool_with_fake_mcp(monkeypatch, tmp_path):
+    """rag_assemble_context should search the indexer and return Markdown."""
+    import sys
+    from types import ModuleType, SimpleNamespace
+
+    class FakeFastMCP:
+        def __init__(self, name):
+            self.name = name
+            self.tools = {}
+
+        def tool(self):
+            def decorator(func):
+                self.tools[func.__name__] = func
+                return func
+
+            return decorator
+
+    class FakeIndexer:
+        last_instance = None
+
+        def __init__(self, persist_directory, enable_persist):
+            self.persist_directory = persist_directory
+            self.enable_persist = enable_persist
+            self.search_calls = []
+            self.cache = {}
+            FakeIndexer.last_instance = self
+
+        def search(self, query, n_results):
+            self.search_calls.append((query, n_results))
+            return (
+                [
+                    SimpleNamespace(
+                        content="Prompt-ready context.",
+                        metadata={"source": "/tmp/context.md"},
+                    )
+                ],
+                [0.25],
+                None,
+            )
+
+        def get_status(self):
+            return {"document_count": 0, "chunk_count": 0}
+
+    mcp_module = ModuleType("mcp")
+    server_module = ModuleType("mcp.server")
+    fastmcp_module = ModuleType("mcp.server.fastmcp")
+    fastmcp_module.__dict__["FastMCP"] = FakeFastMCP
+    server_module.__dict__["fastmcp"] = fastmcp_module
+    mcp_module.__dict__["server"] = server_module
+    monkeypatch.setitem(sys.modules, "mcp", mcp_module)
+    monkeypatch.setitem(sys.modules, "mcp.server", server_module)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fastmcp_module)
+
+    indexer_module = ModuleType("gptme_rag.indexing.indexer")
+    indexer_module.__dict__["Indexer"] = FakeIndexer
+    monkeypatch.setitem(sys.modules, "gptme_rag.indexing.indexer", indexer_module)
+
+    from gptme_rag.mcp_server import build_server
+
+    server = build_server(persist_dir=tmp_path / "idx")
+    output = server.tools["rag_assemble_context"](
+        "agent context",
+        top_k=0,
+        max_context_chars=500,
+    )
+
+    assert FakeIndexer.last_instance is not None
+    assert FakeIndexer.last_instance.search_calls == [("agent context", 1)]
+    assert 'Retrieved Context for: "agent context"' in output
+    assert "[75% relevant] context.md" in output
+    assert "Prompt-ready context." in output
+
+
 def test_cli_mcp_command_registered():
     """The `gptme-rag mcp` subcommand should be discoverable via Click."""
     from gptme_rag.cli import cli


### PR DESCRIPTION
## Summary

Follow-up to #25. Two small post-merge improvements that didn't make it into the PR:

- Extract the indexer-search-then-assemble path from `rag_assemble_context` into a reusable `_assemble_context_from_indexer` helper. Keeps the tool body focused on argument validation and clamping; the helper does the search + assembly.
- Add a fake-MCP unit test (`test_rag_assemble_context_tool_with_fake_mcp`) that monkeypatches `mcp.server.fastmcp` and the `Indexer` so the tool can be exercised end-to-end without a real MCP runtime. This gives the clamping/search/assembly contract direct coverage, complementing the existing `_assemble_context` unit tests.

No behavior change: the tool's I/O contract is unchanged.

## Test plan

- [x] `poetry run pytest tests/test_mcp_server.py -q` — 10 passed, 6 skipped (skips are pre-existing for missing optional deps)
- [x] New test passes: `tests/test_mcp_server.py::test_rag_assemble_context_tool_with_fake_mcp`
- [x] No production-code logic change in `rag_assemble_context`; clamping behavior preserved (`top_k=0 → 1`, `top_k>50 → 50`).

Co-Authored-By: Bob <bob@superuserlabs.org>