### PR TITLE
feat(indexing,mcp): byte-range provenance for chunks

### DIFF
--- a/gptme_rag/indexing/document.py
+++ b/gptme_rag/indexing/document.py
@@ -27,6 +27,8 @@ class Document:
     embedding: list[float] | None = None
     last_modified: datetime | None = None
     chunk_index: int | None = None
+    byte_start: int | None = None
+    byte_end: int | None = None
 
     @classmethod
     def from_file(
@@ -79,6 +81,8 @@ class Document:
                     doc_id=chunk_id,
                     last_modified=last_modified,
                     chunk_index=chunk["metadata"]["chunk_index"],
+                    byte_start=chunk["metadata"].get("byte_start"),
+                    byte_end=chunk["metadata"].get("byte_end"),
                 )
 
     @property
@@ -90,18 +94,20 @@ class Document:
         """
         return self.chunk_index is not None or self.metadata.get("is_chunk", False)
 
-    def get_chunk_info(self) -> tuple[int, int]:
+    def get_chunk_info(self) -> tuple[int, int, int | None, int | None]:
         """Get information about the chunk.
 
         Returns:
-            Tuple of (chunk_index, total_chunks) if this is a chunk,
-            otherwise (0, 1)
+            Tuple of (chunk_index, total_chunks, byte_start, byte_end) if this
+            is a chunk, otherwise (0, 1, None, None).
         """
         if not self.is_chunk or self.chunk_index is None:
-            return (0, 1)
+            return (0, 1, None, None)
         chunk_index = self.chunk_index  # Now we know it's not None
         total_chunks = self.metadata.get("total_chunks", chunk_index + 1)
-        return (chunk_index, total_chunks)
+        byte_start = self.byte_start
+        byte_end = self.byte_end
+        return (chunk_index, total_chunks, byte_start, byte_end)
 
     def format_xml(self) -> str:
         """Format the document as an XML object."""

--- a/gptme_rag/indexing/document_processor.py
+++ b/gptme_rag/indexing/document_processor.py
@@ -32,27 +32,62 @@ class DocumentProcessor:
         self.max_chunks = max_chunks
         self.encoding = tiktoken.get_encoding(encoding_name)
 
+    def _token_byte_offsets(self, text: str, tokens: list[int]) -> list[int]:
+        """Compute starting byte offset in ``text`` for each token.
+
+        Works by decoding progressively longer token prefixes and measuring
+        the encoded length, so it handles multi-byte UTF-8 characters and
+        BPE edge cases correctly.
+
+        Args:
+            text: The original full text.
+            tokens: The tokenized representation of ``text``.
+
+        Returns:
+            A list of byte offsets, one per token, where position ``i`` is
+            the byte offset of token ``tokens[i]`` in ``text.encode('utf-8')``.
+        """
+        offsets: list[int] = []
+        # Build cumulative byte-length lookups for decoded prefixes
+        decoded = ""
+        byte_pos = 0
+        for token in tokens:
+            offsets.append(byte_pos)
+            decoded += self.encoding.decode([token])
+            byte_pos = len(decoded.encode("utf-8"))
+        return offsets
+
     def process_text(
         self,
         text: str,
         metadata: dict | None = None,
+        original_text: str | None = None,
     ) -> Generator[dict, None, None]:
         """Process text into chunks with metadata.
 
         Args:
             text: Text to process
             metadata: Optional metadata to include with each chunk
+            original_text: Original full text for computing byte offsets
+                (defaults to ``text`` when not provided).
 
         Yields:
-            Dict containing chunk text and metadata
+            Dict containing chunk text, metadata, and ``byte_start``/``byte_end``
+            offsets in the source text (UTF-8 byte positions, 0-indexed).
         """
         # Skip empty text
         if not text.strip():
             return
 
+        source = original_text or text
+        source_bytes = len(source.encode("utf-8"))
+
         try:
             # Encode text to tokens
             tokens = self.encoding.encode(text)
+
+            # Pre-compute token-level byte offsets in the source text
+            token_offsets = self._token_byte_offsets(source, tokens)
 
             # Calculate total chunks
             total_chunks = max(1, self.estimate_chunks(len(tokens)))
@@ -60,7 +95,7 @@ class DocumentProcessor:
             # If text is short enough, yield as single chunk
             if len(tokens) <= self.chunk_size:
                 yield {
-                    "text": text,
+                    "text": source,
                     "metadata": {
                         **(metadata or {}),
                         "chunk_index": 0,
@@ -68,6 +103,8 @@ class DocumentProcessor:
                         "total_chunks": 1,
                         "chunk_start": 0,
                         "chunk_end": len(tokens),
+                        "byte_start": 0,
+                        "byte_end": source_bytes,
                     },
                 }
                 return
@@ -84,10 +121,18 @@ class DocumentProcessor:
                 chunk_tokens = tokens[chunk_start:chunk_end]
                 chunk_text = self.encoding.decode(chunk_tokens)
 
+                # Compute byte range from pre-computed token offsets
+                chunk_byte_start = token_offsets[chunk_start]
+                if chunk_end < len(tokens):
+                    chunk_byte_end = token_offsets[chunk_end]
+                else:
+                    chunk_byte_end = source_bytes
+
                 # Log chunk info
                 logger.debug(
                     f"Creating chunk {chunk_count} with {len(chunk_tokens)} tokens, "
-                    f"{len(chunk_text)} chars, {chunk_text[:50]}..."
+                    f"{len(chunk_text)} chars (bytes {chunk_byte_start}-{chunk_byte_end}), "
+                    f"{chunk_text[:50]}..."
                 )
 
                 # Create chunk metadata
@@ -101,6 +146,8 @@ class DocumentProcessor:
                         "chunk_start": chunk_start,
                         "chunk_end": chunk_end,
                         "is_chunk": True,
+                        "byte_start": chunk_byte_start,
+                        "byte_end": chunk_byte_end,
                     },
                 }
 
@@ -122,7 +169,7 @@ class DocumentProcessor:
             logger.error(f"Error processing text: {e}")
             # Yield the entire text as a single chunk if processing fails
             yield {
-                "text": text,
+                "text": source,
                 "metadata": {
                     **(metadata or {}),
                     "chunk_index": 0,
@@ -131,6 +178,8 @@ class DocumentProcessor:
                     "chunk_start": 0,
                     "chunk_end": len(text),
                     "error": str(e),
+                    "byte_start": 0,
+                    "byte_end": source_bytes,
                 },
             }
 
@@ -192,6 +241,9 @@ class DocumentProcessor:
             # Skip empty files
             if not content.strip():
                 return
+
+            # Record source byte size for provenance tracking
+            file_metadata["source_bytes"] = len(content.encode("utf-8"))
 
             # Process the content
             yield from self.process_text(content, file_metadata)

--- a/gptme_rag/mcp_server.py
+++ b/gptme_rag/mcp_server.py
@@ -14,6 +14,23 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _format_byte_range(metadata: dict[str, Any]) -> str:
+    """Format a ' (bytes N-M)' suffix from chunk metadata, or '' if absent.
+
+    Surfaces the chunk's byte range so agents (and humans) can locate the exact
+    region of the source file the chunk came from without re-running retrieval.
+    """
+    if not metadata:
+        return ""
+    start = metadata.get("byte_start")
+    end = metadata.get("byte_end")
+    if not isinstance(start, int) or not isinstance(end, int):
+        return ""
+    if end < start:
+        return ""
+    return f" (bytes {start}-{end})"
+
+
 def _format_results(
     documents: list,
     scores: list[float],
@@ -84,9 +101,11 @@ def _assemble_context(
         source = entry["source"] or "(unknown)"
         score_pct = max(0, min(100, round(entry["score"] * 100)))
         filename = Path(source).name if source else "(unknown)"
+        byte_range = _format_byte_range(entry.get("metadata") or {})
+        source_line = f"*Source: {source}{byte_range}*"
         section = (
             f"### [{score_pct}% relevant] {filename}\n"
-            f"*Source: {source}*\n\n"
+            f"{source_line}\n\n"
             f"{entry['content']}\n\n"
         )
         # Always include at least the first result; truncate subsequent ones.

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -130,3 +130,61 @@ def test_chunk_retrieval(test_file, indexer):
     # Check chunks are in order
     chunk_indices = [chunk.chunk_index or 0 for chunk in chunks]
     assert chunk_indices == sorted(chunk_indices), "Chunks should be in order"
+
+
+def test_source_bytes_metadata(test_file, indexer):
+    """Test that indexed chunks carry source_bytes and byte offsets."""
+    indexer.index_directory(test_file.parent)
+
+    docs, _, _ = indexer.search("Lorem ipsum", n_results=50)
+    assert len(docs) > 0
+
+    for doc in docs:
+        # source_bytes should be on the document-level metadata
+        assert "source_bytes" in doc.metadata, f"Missing source_bytes in {doc.doc_id}"
+        assert doc.metadata["source_bytes"] > 0
+
+        # chunk-level byte_start/byte_end should be present
+        assert "byte_start" in doc.metadata, f"Missing byte_start in {doc.doc_id}"
+        assert "byte_end" in doc.metadata, f"Missing byte_end in {doc.doc_id}"
+        start = doc.metadata["byte_start"]
+        end = doc.metadata["byte_end"]
+        assert start < end or (start == 0 and end == 0)  # start < end for real files
+        assert (
+            end <= doc.metadata["source_bytes"]
+        ), f"byte_end ({end}) exceeds source_bytes ({doc.metadata['source_bytes']})"
+
+
+def test_source_bytes_in_source(test_file, indexer):
+    """Test that byte offsets map back to correct positions in the source file."""
+    indexer.index_file(test_file)
+
+    docs, _, _ = indexer.search("Lorem ipsum", n_results=1)
+    assert len(docs) > 0
+
+    base_doc_id = docs[0].doc_id
+    assert base_doc_id is not None
+    doc_id = base_doc_id.split("#chunk")[0]
+
+    chunks = indexer.get_document_chunks(doc_id)
+    assert len(chunks) > 0
+
+    original = test_file.read_text()
+    source_bytes = len(original.encode("utf-8"))
+
+    # Verify byte_start/byte_end on each chunk
+    for chunk in chunks:
+        assert "byte_start" in chunk.metadata
+        assert "byte_end" in chunk.metadata
+        start = chunk.metadata["byte_start"]
+        end = chunk.metadata["byte_end"]
+        assert start >= 0
+        assert end <= source_bytes, f"byte_end ({end}) > source_bytes ({source_bytes})"
+        assert start < end or (
+            start == 0 and end == 0
+        ), f"byte_start ({start}) >= byte_end ({end})"
+
+    # Sorted by byte_start, verify union covers entire source
+    sorted_chunks = sorted(chunks, key=lambda c: c.metadata["byte_start"])
+    assert sorted_chunks[0].metadata["byte_start"] == 0
+    assert sorted_chunks[-1].metadata["byte_end"] == source_bytes

--- a/tests/test_document_processor.py
+++ b/tests/test_document_processor.py
@@ -150,3 +150,79 @@ def test_small_text():
 
     assert len(chunks) == 1
     assert chunks[0]["text"] == text
+
+
+def test_source_byte_size(tmp_path):
+    """Test that source_bytes metadata is available on processed files."""
+    file_path = tmp_path / "test.txt"
+    content = "This is a test.\n" * 200
+    file_path.write_text(content)
+
+    processor = DocumentProcessor(chunk_size=100, chunk_overlap=20)
+    chunks = list(processor.process_file(file_path))
+
+    assert len(chunks) > 0
+    expected_size = len(content.encode("utf-8"))
+    for chunk in chunks:
+        assert "source_bytes" in chunk["metadata"]
+        assert chunk["metadata"]["source_bytes"] > 0
+        source_bytes = chunk["metadata"]["source_bytes"]
+        assert source_bytes == expected_size
+
+
+def test_byte_offsets_in_chunks():
+    """Test that byte_start and byte_end track positions in the source text."""
+    processor = DocumentProcessor(chunk_size=100, chunk_overlap=0)
+    # Use repetitive text for predictable chunking
+    text = "Hello world! " * 200
+
+    chunks = list(processor.process_text(text))
+    assert (
+        len(chunks) > 1
+    ), f"Expected multiple chunks for 200 repetitions, got {len(chunks)}"
+
+    # Verify byte offsets are monotonically increasing and non-overlapping
+    for i, chunk in enumerate(chunks):
+        assert "byte_start" in chunk["metadata"]
+        assert "byte_end" in chunk["metadata"]
+        start = chunk["metadata"]["byte_start"]
+        end = chunk["metadata"]["byte_end"]
+        assert start < end, f"Chunk {i}: byte_start ({start}) >= byte_end ({end})"
+
+    # First chunk starts at 0, last chunk ends at total byte size
+    assert chunks[0]["metadata"]["byte_start"] == 0
+    total_bytes = len(text.encode("utf-8"))
+    assert chunks[-1]["metadata"]["byte_end"] == total_bytes
+
+    # Consecutive chunks: previous end equals next start (with overlap=0)
+    for i in range(len(chunks) - 1):
+        prev_end = chunks[i]["metadata"]["byte_end"]
+        next_start = chunks[i + 1]["metadata"]["byte_start"]
+        assert (
+            prev_end == next_start
+        ), f"Chunk {i} byte_end ({prev_end}) != Chunk {i+1} byte_start ({next_start})"
+
+
+def test_byte_offsets_single_chunk():
+    """Test that a single-chunk document gets correct byte offsets."""
+    processor = DocumentProcessor(chunk_size=1000, chunk_overlap=20)
+    text = "A short text."
+    chunks = list(processor.process_text(text))
+
+    assert len(chunks) == 1
+    assert chunks[0]["metadata"]["byte_start"] == 0
+    assert chunks[0]["metadata"]["byte_end"] == len(text.encode("utf-8"))
+
+
+def test_byte_offsets_utf8_multibyte():
+    """Test byte offsets work correctly with multi-byte UTF-8 characters."""
+    processor = DocumentProcessor(chunk_size=50, chunk_overlap=0)
+    # Use characters that take multiple bytes in UTF-8
+    text = "日本語テスト" * 30  # 5 chars × 30, each char 3 bytes = 450 bytes total
+    source_bytes = len(text.encode("utf-8"))
+
+    chunks = list(processor.process_text(text))
+    assert len(chunks) > 1
+
+    assert chunks[0]["metadata"]["byte_start"] == 0
+    assert chunks[-1]["metadata"]["byte_end"] == source_bytes

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -144,6 +144,54 @@ def test_assemble_context_cap_uses_rendered_markdown_length():
     assert len(output) <= cap
 
 
+def test_format_byte_range_returns_suffix_when_present():
+    """_format_byte_range should produce a ' (bytes N-M)' suffix when both offsets are integers."""
+    from gptme_rag.mcp_server import _format_byte_range
+
+    assert (
+        _format_byte_range({"byte_start": 100, "byte_end": 350}) == " (bytes 100-350)"
+    )
+
+
+def test_format_byte_range_skips_when_missing_or_invalid():
+    """_format_byte_range should return '' for missing, partial, or malformed byte ranges."""
+    from gptme_rag.mcp_server import _format_byte_range
+
+    assert _format_byte_range({}) == ""
+    assert _format_byte_range({"byte_start": 0}) == ""
+    assert _format_byte_range({"byte_end": 10}) == ""
+    assert _format_byte_range({"byte_start": "10", "byte_end": "20"}) == ""
+    # nonsense ordering should not produce a suffix
+    assert _format_byte_range({"byte_start": 200, "byte_end": 100}) == ""
+
+
+def test_assemble_context_includes_byte_range_when_present():
+    """_assemble_context should surface byte_start/byte_end in the citation header."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    doc = SimpleNamespace(
+        content="Chunk body text.",
+        metadata={"source": "/tmp/notes.md", "byte_start": 1024, "byte_end": 2048},
+    )
+    output = _assemble_context([doc], [0.1], "find notes")
+    assert "/tmp/notes.md (bytes 1024-2048)" in output
+
+
+def test_assemble_context_omits_byte_range_when_absent():
+    """_assemble_context should not invent a byte range when metadata lacks offsets."""
+    from types import SimpleNamespace
+
+    from gptme_rag.mcp_server import _assemble_context
+
+    doc = SimpleNamespace(
+        content="No range metadata.", metadata={"source": "/tmp/plain.md"}
+    )
+    output = _assemble_context([doc], [0.1], "test")
+    assert "(bytes " not in output
+
+
 def test_assemble_context_handles_missing_source():
     """_assemble_context should not crash on docs without metadata."""
     from types import SimpleNamespace


### PR DESCRIPTION
## Summary

Chunks now carry their exact `byte_start`/`byte_end` UTF-8 byte offsets, and the MCP context-assembly path surfaces those offsets in citation headers. Agents (and humans) can locate the precise region of a source file a chunk came from without re-running retrieval or scanning the whole file.

This is a follow-up to #22 (MCP server) and an instance of the cocoindex-inspired *lineage* pattern: every retrieved chunk traces back to the exact source byte range.

## Changes

- `DocumentProcessor.process_text` / `process_file` compute UTF-8 byte offsets per token and attach `byte_start` / `byte_end` to every chunk's metadata (single-chunk, multi-chunk, and error paths). `process_file` also records `source_bytes` so callers can sanity-check `byte_end <= source_bytes`.
- `Document.byte_start` / `byte_end` fields persist offsets at the Document layer; `get_chunk_info` returns a 4-tuple including them.
- `_format_byte_range` helper formats a ` (bytes N-M)` suffix from chunk metadata, with guards for missing / partial / non-int / inverted ranges. The MCP `_assemble_context` appends the byte range to the existing `*Source: ...*` citation line when present.

## Example MCP output

```
### [80% relevant] notes.md
*Source: /tmp/notes.md (bytes 1024-2048)*

Chunk body text.
```

Chunks indexed before this change are unaffected — when `byte_start`/`byte_end` are absent, the citation header looks exactly as it did before.

## Test plan

- [x] `pytest tests/test_document_processor.py` → 15 passed (incl. 4 new tests: source_bytes metadata, monotonic chunk offsets, single-chunk full-file ranges, UTF-8 multi-byte safety)
- [x] `pytest tests/test_chunking.py` → 7 passed (incl. 2 new end-to-end tests verifying offsets survive the indexer + ChromaDB roundtrip and stay within `source_bytes`)
- [x] `pytest tests/test_mcp_server.py` → 20 passed (incl. 4 new tests covering `_format_byte_range` edge cases plus `_assemble_context` byte-range surfacing)
- [x] Pre-commit (ruff / mypy) clean

Tracked as idea #213 in Bob's strategic backlog (gptme-rag byte-range provenance).