### PR TITLE
docs: deprecate — upstreamed into gptme-contrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # gptme-rag
 
+> **This repository has been upstreamed into [gptme-contrib](https://github.com/gptme/gptme-contrib).**
+> Please use the package from there: [`packages/gptme-rag`](https://github.com/gptme/gptme-contrib/tree/master/packages/gptme-rag).
+> This repo is archived and will no longer receive updates.
+
 A powerful RAG (Retrieval-Augmented Generation) system that enhances AI interactions by providing relevant context from your local files. Built primarily for [gptme](https://github.com/ErikBjare/gptme), but can be used standalone.
 
 RAG systems improve AI responses by retrieving and incorporating relevant information from a knowledge base into the generation process. This leads to more accurate, contextual, and factual responses.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **This repository has been upstreamed into [gptme-contrib](https://github.com/gptme/gptme-contrib).**
 > Please use the package from there: [`packages/gptme-rag`](https://github.com/gptme/gptme-contrib/tree/master/packages/gptme-rag).
-> This repo is archived and will no longer receive updates.
+> This repo will be archived and will no longer receive updates.
 
 A powerful RAG (Retrieval-Augmented Generation) system that enhances AI interactions by providing relevant context from your local files. Built primarily for [gptme](https://github.com/ErikBjare/gptme), but can be used standalone.
 


### PR DESCRIPTION
## Summary

- Adds a deprecation banner to the README pointing users to the new canonical home: [`gptme-contrib/packages/gptme-rag`](https://github.com/gptme/gptme-contrib/tree/master/packages/gptme-rag)
- The code was upstreamed in gptme/gptme-contrib#1223 (squash-merged 2026-07-04)

## Next step

After this PR merges, the repo should be archived via GitHub repo settings (Settings → Danger Zone → Archive).

Closes gptme/gptme-contrib#1221 (pending archive).